### PR TITLE
Fix Protobuf installation issue and update version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(WIN32)
   endforeach()
 endif()
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf 3.6 REQUIRED)
 
 # Make sure protoc is present, as apparently the above find_package() doesn't check that.
 if(NOT PROTOBUF_PROTOC_EXECUTABLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ if(WIN32)
   endforeach()
 endif()
 
+set(Protobuf_PROTOC_EXECUTABLE "/usr/bin/protoc")
 find_package(Protobuf 3.6 REQUIRED)
 
 # Make sure protoc is present, as apparently the above find_package() doesn't check that.


### PR DESCRIPTION
Resolve an error related to Protobuf by specifying the Protoc executable path and updating the required version to 3.6. Additionally, address installation issues.